### PR TITLE
change : getColor() method deprecated

### DIFF
--- a/app/src/main/java/com/cometchat/pro/androiduikit/ComponentFragments/AvatarFragment.java
+++ b/app/src/main/java/com/cometchat/pro/androiduikit/ComponentFragments/AvatarFragment.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
 import com.cometchat.pro.androiduikit.R;
@@ -19,6 +20,8 @@ import com.cometchat.pro.uikit.ui_components.shared.cometchatAvatar.CometChatAva
 import com.cometchat.pro.uikit.ui_resources.utils.Utils;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
+
+import java.util.Objects;
 
 public class AvatarFragment extends Fragment {
 
@@ -174,13 +177,13 @@ public class AvatarFragment extends Fragment {
 
     private void checkDarkMode() {
         if(Utils.isDarkMode(getContext())) {
-            borderWidthLayout.setDefaultHintTextColor(ColorStateList.valueOf(getResources().getColor(R.color.textColorWhite)));
-            borderWidthLayout.setHintTextColor(ColorStateList.valueOf(getResources().getColor(R.color.textColorWhite)));
-            borderWidthLayout.setBoxStrokeColor(getResources().getColor(R.color.textColorWhite));
+            borderWidthLayout.setDefaultHintTextColor(ColorStateList.valueOf(ContextCompat.getColor(Objects.requireNonNull(getActivity()), R.color.textColorWhite)));
+            borderWidthLayout.setHintTextColor(ColorStateList.valueOf(ContextCompat.getColor(Objects.requireNonNull(getActivity()), R.color.textColorWhite)));
+            borderWidthLayout.setBoxStrokeColor(ContextCompat.getColor(getActivity(), R.color.textColorWhite));
         } else {
-            borderWidthLayout.setDefaultHintTextColor(ColorStateList.valueOf(getResources().getColor(R.color.primaryTextColor)));
-            borderWidthLayout.setHintTextColor(ColorStateList.valueOf(getResources().getColor(R.color.primaryTextColor)));
-            borderWidthLayout.setBoxStrokeColor(getResources().getColor(R.color.primaryTextColor));
+            borderWidthLayout.setDefaultHintTextColor(ColorStateList.valueOf(ContextCompat.getColor(Objects.requireNonNull(getActivity()), R.color.primaryTextColor)));
+            borderWidthLayout.setHintTextColor(ColorStateList.valueOf(ContextCompat.getColor(getActivity(), R.color.primaryTextColor)));
+            borderWidthLayout.setBoxStrokeColor(ContextCompat.getColor(getActivity(), R.color.primaryTextColor));
         }
     }
 


### PR DESCRIPTION
Hello I'm android student developer.
I just thought your java chat app is very nice and interesting so when i was looking your code found deprecated code.
but it's not important but if don't mind you would change my code :)
and then you should see this reference
thanks for listening 👍 
[(https://developer.android.com/reference/android/support/v4/content/ContextCompat.html#getColor(android.content.Context,%20int))](url)